### PR TITLE
Split Wonder into WonderType and WonderSide

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use crate::card::Card;
 use crate::player::PlayerBoard;
-use crate::wonder::Wonder;
+use crate::wonder::{WonderType, WonderSide};
 
 mod card;
 mod wonder;
@@ -11,6 +11,6 @@ mod player;
 fn main() {
     let card = Card::Baths;
     println!("Baths cost {:?}", card.cost());
-    let player = PlayerBoard::new(Wonder::ColossusOfRhodesA);
+    let player = PlayerBoard::new(WonderType::ColossusOfRhodes, WonderSide::A);
     println!("Can play Tree Farm? {}", player.can_play(Card::TreeFarm));
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,16 +1,17 @@
 use crate::card::Card;
 use crate::power::Power;
 use crate::resources::{ProducedResources, Resources};
-use crate::wonder::Wonder;
+use crate::wonder::{WonderBoard, WonderType, WonderSide};
 
 #[allow(dead_code)]
 pub struct PlayerBoard {
-    wonder: Wonder,
+    wonder: WonderBoard,
     built_structures: Vec<Card>,
     built_wonder_stages: Vec<Option<Card>>, // TODO: how to represent this?
     coins: u32,
 }
 
+#[allow(dead_code)]
 impl PlayerBoard {
     pub(crate) fn build_structure(&mut self, structure: Card) -> bool {
         return if self.can_play(structure) {
@@ -23,9 +24,9 @@ impl PlayerBoard {
 }
 
 impl PlayerBoard {
-    pub fn new(wonder: Wonder) -> PlayerBoard {
+    pub fn new(wonder_type: WonderType, wonder_side: WonderSide) -> PlayerBoard {
         return PlayerBoard {
-            wonder,
+            wonder: WonderBoard { wonder_type, wonder_side },
             built_structures: vec![],
             built_wonder_stages: vec![],
             coins: 3,
@@ -98,10 +99,9 @@ impl PlayerBoard {
 
 #[cfg(test)]
 mod tests {
-    use std::intrinsics::transmute;
     use crate::card::Card;
     use crate::player::PlayerBoard;
-    use crate::wonder::Wonder;
+    use crate::wonder::{WonderType, WonderSide};
 
     #[test]
     fn can_play_return_true_when_player_can_afford_card() {
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn should_can_play_return_false_when_player_cannot_pay() {
-        let mut player = PlayerBoard::new(Wonder::ColossusOfRhodesA);
+        let mut player = PlayerBoard::new(WonderType::ColossusOfRhodes, WonderSide::A);
         player.coins = 0; //TODO introduce a Bank type to allow for double-entry bookkeeping instead of this
         assert_eq!(false, player.can_play(Card::TreeFarm));
     }
@@ -132,7 +132,6 @@ mod tests {
     }
 
     fn create_player() -> PlayerBoard {
-        let mut player = PlayerBoard::new(Wonder::ColossusOfRhodesA);
-        player
+        PlayerBoard::new(WonderType::ColossusOfRhodes, WonderSide::A)
     }
 }

--- a/src/wonder.rs
+++ b/src/wonder.rs
@@ -1,42 +1,89 @@
-use crate::power::Power;
 use crate::resources::Resources;
 
 #[derive(Debug)]
-pub enum Wonder {
-    ColossusOfRhodesA
+#[allow(dead_code)]
+pub enum WonderType {
+    ColossusOfRhodes,
+    LighthouseOfAlexandria,
+    TempleOfArtemis,
+    HangingGardensOfBabylon,
+    StatueOfZeus,
+    MausoleumOfHalicarnassus,
+    PyramidsOfGiza
 }
 
 #[allow(dead_code)]
-impl Wonder {
+pub enum WonderSide {
+    A,
+    B
+}
+
+pub struct WonderBoard {
+    pub wonder_type: WonderType,
+    pub wonder_side: WonderSide
+}
+
+#[allow(dead_code)]
+impl WonderType {
     fn name(&self) -> &str {
         match self {
-            Wonder::ColossusOfRhodesA => "Colossus of Rhodes",
+            WonderType::ColossusOfRhodes => "The Colossus of Rhodes",
+            WonderType::LighthouseOfAlexandria => "The Lighthouse of Alexandria",
+            WonderType::TempleOfArtemis => "The Temple of Artemis in Aphesus",
+            WonderType::HangingGardensOfBabylon => "The Hanging Gardens of Babylon",
+            WonderType::StatueOfZeus => "The Statue of Zeus in Olympia",
+            WonderType::MausoleumOfHalicarnassus => "The Mausoleum of Halicarnassus",
+            WonderType::PyramidsOfGiza => "The Pyramids of Giza"
         }
+    }
+
+    fn starting_resource(&self) -> Resources {
+        match self {
+            WonderType::ColossusOfRhodes => Resources::ore(1),
+            WonderType::LighthouseOfAlexandria => Resources::glass(1),
+            WonderType::TempleOfArtemis => Resources::papyrus(1),
+            WonderType::HangingGardensOfBabylon => Resources::clay(1),
+            WonderType::StatueOfZeus => Resources::wood(1),
+            WonderType::MausoleumOfHalicarnassus => Resources::loom(1),
+            WonderType::PyramidsOfGiza => Resources::stone(1),
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl WonderBoard {
+    pub fn name(&self) -> &str {
+        self.wonder_type.name()
     }
 
     pub fn starting_resource(&self) -> Resources {
-        match self {
-            Wonder::ColossusOfRhodesA => Resources::ore(1),
-        }
-    }
-}
-
-#[allow(dead_code)]
-pub enum WonderSlot {
-    ColossusOfRhodesASlot1
-}
-
-#[allow(dead_code)]
-impl WonderSlot {
-    pub fn cost(&self) -> Resources {
-        match self {
-            WonderSlot::ColossusOfRhodesASlot1 => Resources::wood(2),
-        }
+        self.wonder_type.starting_resource()
     }
 
-    fn power(&self) -> Power {
-        match self {
-            WonderSlot::ColossusOfRhodesASlot1 => Power::VictoryPoints(3),
+    pub fn cost(&self, position: u32) -> Resources {
+        match (&self.wonder_type, &self.wonder_side, position) {
+            (WonderType::ColossusOfRhodes, WonderSide::A, 0) => Resources::wood(2),
+            (WonderType::ColossusOfRhodes, WonderSide::A, 1) => Resources::clay(3),
+            (WonderType::ColossusOfRhodes, WonderSide::A, 2) => Resources::ore(4),
+            (WonderType::ColossusOfRhodes, WonderSide::A, _) => panic!(),
+
+            (WonderType::ColossusOfRhodes, WonderSide::B, 0) => Resources::stone(3),
+            (WonderType::ColossusOfRhodes, WonderSide::B, 1) => Resources::ore(4),
+            (WonderType::ColossusOfRhodes, WonderSide::B, _) => panic!(),
+
+            (WonderType::LighthouseOfAlexandria, WonderSide::A, 0) => Resources::stone(2),
+            (WonderType::LighthouseOfAlexandria, WonderSide::A, 1) => Resources::ore(2),
+            (WonderType::LighthouseOfAlexandria, WonderSide::A, 2) => Resources::glass(2),
+            (WonderType::LighthouseOfAlexandria, WonderSide::A, _) => panic!(),
+
+            (WonderType::LighthouseOfAlexandria, WonderSide::B, 0) => Resources::clay(2),
+            (WonderType::LighthouseOfAlexandria, WonderSide::B, 1) => Resources::wood(2),
+            (WonderType::LighthouseOfAlexandria, WonderSide::B, 2) => Resources::stone(3),
+            (WonderType::LighthouseOfAlexandria, WonderSide::B, _) => panic!(),
+
+            _ => todo!()
         }
     }
+
+    // TODO: power
 }


### PR DESCRIPTION
It was always a bit nasty that we had enum values like
"ColossusOfRhodesA". We also need to be able to randomly choose wonders
for players when initialising a game, and need to prevent one player
getting ColossusOfRhodesA while another gets ColossusOfRhodesB.

Split into a type and a side, and introduce a struct, "WonderBoard" that
holds the two.