### PR TITLE
Support borrowing of resources from neighbours

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -1,0 +1,81 @@
+//! An action defines what a user does each turn (builds a structure, builds a wonder stage, discards a card).
+
+use crate::card::Card;
+use std::fmt::{Display, Formatter};
+use std::fmt;
+use crate::game::VisibleGame;
+use std::collections::HashSet;
+use std::iter::FromIterator;
+use crate::power::Power;
+use crate::player::PublicPlayer;
+
+/// Represents an action.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum Action {
+    Build(Card, Borrowing),
+    Wonder(Card, Borrowing),
+    Discard(Card),
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Build(card, _) => write!(f, "Build {}", card.to_string()),
+            Action::Wonder(card, _) => write!(f, "Use {} to build a wonder stage", card.to_string()),
+            Action::Discard(card) => write!(f, "Discard {}", card.to_string()),
+        }
+    }
+}
+
+/// Represents resources borrowed from left and right neighbours as part of an action.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Borrowing {
+    pub left: Vec<Borrow>,
+    pub right: Vec<Borrow>,
+}
+
+impl Borrowing {
+    pub fn new(left: Vec<Borrow>, right: Vec<Borrow>) -> Borrowing {
+        Borrowing { left, right }
+    }
+
+    /// Convenience constructor when no borrowing is required.
+    pub fn no_borrowing() -> Borrowing {
+        Self::new(vec![], vec![])
+    }
+
+    /// Returns true if this borrowing plan is possible for the given game state.
+    pub fn valid(&self, visible_game: &VisibleGame) -> bool {
+        fn valid_on(borrows: &[Borrow], neighbour: &PublicPlayer) -> bool {
+            let neighbour_structures = HashSet::<&Card>::from_iter(&neighbour.built_structures);
+            borrows.iter().all(|borrow| neighbour_structures.contains(&borrow.card))
+        }
+        valid_on(&self.left, &visible_game.left_neighbour()) && valid_on(&self.right, &visible_game.right_neighbour())
+    }
+}
+
+/// Represents the borrowing of a specific resource.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct Borrow {
+    /// The card the resource is on.
+    card: Card,
+    /// The index of the resource on the card that is being borrowed. Always 0 except for resources that generate two
+    /// resources in one go (ie. [`Sawmill`], [`Quarry`], [`Brickyard`], and [`Foundry`]), where the first resource is 0
+    /// and the second resource is 1.
+    index: u32,
+}
+
+impl Borrow {
+    pub fn new(card: Card, index: u32) -> Borrow {
+        if index > 1 {
+            panic!("index must be 0 or 1");
+        }
+        if let Power::Producer(resources) | Power::PurchasableProducer(resources) = card.power() {
+            if index == 1 && (resources.len() != 1 || resources[0].max() != 2) {
+                panic!("index can only be 1 if card is a double production card");
+            }
+        }
+        Borrow { card, index }
+    }
+}

--- a/src/algorithms/human.rs
+++ b/src/algorithms/human.rs
@@ -4,9 +4,10 @@ use std::io;
 use std::io::Write;
 
 use crate::algorithms::PlayingAlgorithm;
-use crate::game::{Action, VisibleGame};
+use crate::game::VisibleGame;
 use crate::player::Player;
 use crate::table::Table;
+use crate::action::{Action, Borrowing};
 
 #[derive(Debug)]
 pub struct Human;
@@ -85,7 +86,7 @@ impl Human {
                 let mut choice = String::new();
                 io::stdin().read_line(&mut choice).unwrap();
                 match choice.trim().to_lowercase().as_str() {
-                    "b" => break Action::Build(card),
+                    "b" => break Action::Build(card, Borrowing::no_borrowing()),
                     "d" => break Action::Discard(card),
                     _ => {},
                 };

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -2,7 +2,8 @@
 
 use std::fmt::Debug;
 
-use crate::game::{Action, VisibleGame};
+use crate::action::Action;
+use crate::game::VisibleGame;
 use crate::player::Player;
 
 pub mod human;

--- a/src/algorithms/random.rs
+++ b/src/algorithms/random.rs
@@ -4,20 +4,23 @@
 use rand::prelude::*;
 
 use crate::algorithms::PlayingAlgorithm;
-use crate::game::{Action, VisibleGame};
+use crate::game::{VisibleGame};
 use crate::player::Player;
+use crate::action::Action;
 
 #[derive(Debug)]
 pub struct Random;
 
 impl PlayingAlgorithm for Random {
-    fn get_next_action(&self, player: &Player, _visible_game: &VisibleGame) -> Action {
-        let card_to_build = player.hand().iter()
-            .filter(|card| player.can_play(&Action::Build(**card), _visible_game))
+    fn get_next_action(&self, player: &Player, visible_game: &VisibleGame) -> Action {
+        let action_to_take = player.hand().iter()
+            .map(|card| player.options_for_card(card, visible_game))
+            .filter(|actions| !actions.is_empty())
+            .map(|mut actions| actions.swap_remove(thread_rng().gen_range(0, actions.len())))
             .choose(&mut thread_rng());
 
-        match card_to_build {
-            Some(card) => Action::Build(*card),
+        match action_to_take {
+            Some(action) => action,
             None => Action::Discard(*player.hand().iter()
                 .choose(&mut thread_rng())
                 .unwrap())

--- a/src/card.rs
+++ b/src/card.rs
@@ -6,13 +6,12 @@ use rand::thread_rng;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-
 use crate::power::{CountableGameItem, ScienceItem};
 use crate::power::PerGameItemReward;
 use crate::power::Power;
-use crate::resources::{ProducedResources, Resources};
+use crate::resources::Resources;
 
-#[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, EnumIter)]
 #[allow(dead_code)]
 pub enum Card {
 
@@ -180,7 +179,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::wood(1))),
+                power: Power::PurchasableProducer(vec![Resources::wood(1)]),
             },
 
             Card::StonePit => CardInfo {
@@ -190,7 +189,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::stone(1))),
+                power: Power::PurchasableProducer(vec![Resources::stone(1)]),
             },
 
             Card::ClayPool => CardInfo {
@@ -200,7 +199,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::clay(1))),
+                power: Power::PurchasableProducer(vec![Resources::clay(1)]),
             },
 
             Card::OreVein => CardInfo {
@@ -210,7 +209,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::ore(1))),
+                power: Power::PurchasableProducer(vec![Resources::ore(1)]),
             },
 
             Card::TreeFarm => CardInfo {
@@ -220,9 +219,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Choice(vec![
-                    Resources::wood(1),
-                    Resources::clay(1)])),
+                power: Power::PurchasableProducer(vec![Resources::wood(1), Resources::clay(1)]),
             },
 
             Card::Excavation => CardInfo {
@@ -232,9 +229,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Choice(vec![
-                    Resources::stone(1),
-                    Resources::clay(1)])),
+                power: Power::PurchasableProducer(vec![Resources::stone(1), Resources::clay(1)]),
             },
 
             Card::ClayPit => CardInfo {
@@ -244,9 +239,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Choice(vec![
-                    Resources::clay(1),
-                    Resources::ore(1)])),
+                power: Power::PurchasableProducer(vec![Resources::clay(1), Resources::ore(1)]),
             },
 
             Card::TimberYard => CardInfo {
@@ -256,9 +249,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Choice(vec![
-                    Resources::stone(1),
-                    Resources::wood(1)])),
+                power: Power::PurchasableProducer(vec![Resources::stone(1), Resources::wood(1)]),
             },
 
             Card::ForestCave => CardInfo {
@@ -268,9 +259,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Choice(vec![
-                    Resources::wood(1),
-                    Resources::ore(1)])),
+                power: Power::PurchasableProducer(vec![Resources::wood(1), Resources::ore(1)]),
             },
 
             Card::Mine => CardInfo {
@@ -280,9 +269,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Choice(vec![
-                    Resources::ore(1),
-                    Resources::stone(1)])),
+                power: Power::PurchasableProducer(vec![Resources::ore(1), Resources::stone(1)]),
             },
 
             Card::Loom1 => CardInfo {
@@ -292,7 +279,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Grey,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::loom(1))),
+                power: Power::PurchasableProducer(vec![Resources::loom(1)]),
             },
 
             Card::Glassworks1 => CardInfo {
@@ -302,7 +289,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Grey,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::glass(1))),
+                power: Power::PurchasableProducer(vec![Resources::glass(1)]),
             },
 
             Card::Press1 => CardInfo {
@@ -312,7 +299,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Grey,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::papyrus(1))),
+                power: Power::PurchasableProducer(vec![Resources::papyrus(1)]),
             },
 
             Card::Pawnshop => CardInfo {
@@ -462,7 +449,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::wood(2))),
+                power: Power::PurchasableProducer(vec![Resources::wood(2)]),
             },
 
             Card::Quarry => CardInfo {
@@ -472,7 +459,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::stone(2))),
+                power: Power::PurchasableProducer(vec![Resources::stone(2)]),
             },
 
             Card::Brickyard => CardInfo {
@@ -482,7 +469,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::clay(2))),
+                power: Power::PurchasableProducer(vec![Resources::clay(2)]),
             },
 
             Card::Foundry => CardInfo {
@@ -492,7 +479,7 @@ impl Card {
                 cost: Resources::coins(1),
                 chains_to: vec![],
                 colour: Colour::Brown,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::ore(2))),
+                power: Power::PurchasableProducer(vec![Resources::ore(2)]),
             },
 
             Card::Loom2 => CardInfo {
@@ -502,7 +489,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Grey,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::loom(1))),
+                power: Power::PurchasableProducer(vec![Resources::loom(1)]),
             },
 
             Card::Glassworks2 => CardInfo {
@@ -512,7 +499,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Grey,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::glass(1))),
+                power: Power::PurchasableProducer(vec![Resources::glass(1)]),
             },
 
             Card::Press2 => CardInfo {
@@ -522,7 +509,7 @@ impl Card {
                 cost: Resources::free(),
                 chains_to: vec![],
                 colour: Colour::Grey,
-                power: Power::PurchasableProducer(ProducedResources::Single(Resources::papyrus(1))),
+                power: Power::PurchasableProducer(vec![Resources::papyrus(1)]),
             },
 
             Card::Aqueduct => CardInfo {
@@ -572,10 +559,7 @@ impl Card {
                 cost: Resources::clay(2),
                 chains_to: vec![Card::Haven],
                 colour: Colour::Yellow,
-                power: Power::Producer(ProducedResources::Choice(vec![
-                    Resources::loom(1),
-                    Resources::glass(1),
-                    Resources::papyrus(1)])),
+                power: Power::Producer(vec![Resources::loom(1), Resources::glass(1), Resources::papyrus(1)]),
             },
 
             Card::Caravansery => CardInfo {
@@ -585,11 +569,11 @@ impl Card {
                 cost: Resources::wood(2),
                 chains_to: vec![Card::Lighthouse],
                 colour: Colour::Yellow,
-                power: Power::Producer(ProducedResources::Choice(vec![
+                power: Power::Producer(vec![
                     Resources::wood(1),
                     Resources::stone(1),
                     Resources::ore(1),
-                    Resources::clay(1)])),
+                    Resources::clay(1)]),
             },
 
             Card::Vineyard => CardInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod game;
 mod utils;
 mod table;
 mod algorithms;
+mod action;
 
 fn main() {
     let mut game = Game::new(vec![Box::new(Human {}), Box::new(Random {}), Box::new(Random {})]);

--- a/src/power.rs
+++ b/src/power.rs
@@ -1,23 +1,25 @@
 //! Represents what a card or a wonder stage does for a player (for example, delivers victory points, or gives access to
 //! a scientific structure).
 
-use crate::card::{Card, Colour};
-use crate::resources::ProducedResources;
-use strum_macros::EnumIter;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
 use itertools::Itertools;
+use strum_macros::EnumIter;
 
+use crate::card::{Card, Colour};
+use crate::resources::Resources;
 use crate::utils::plural;
 
 /// Represents what a card or a wonder stage does for a player (for example, delivers victory points, or gives access to
 /// a scientific structure).
 pub enum Power {
-    /// Produces resources that are purchasable by a neighbour (ie. brown and grey cards).
-    PurchasableProducer(ProducedResources),
-    /// Produces resources that are not purchasable by a neighbour.
-    Producer(ProducedResources),
+    /// Produces resources that are purchasable by a neighbour (ie. brown and grey cards). The vector contains a single
+    /// [`Resources`] item for normal resources, or more than one to represent a choice of resources.
+    PurchasableProducer(Vec<Resources>),
+    /// Produces resources that are not purchasable by a neighbour. The vector contains a single [`Resources`] item for
+    /// normal resources, or more than one to represent a choice of resources.
+    Producer(Vec<Resources>),
     /// Provides victory points.
     VictoryPoints(u32),
     /// Provides coins.
@@ -69,17 +71,15 @@ impl Power {
 impl Display for Power {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", match self {
-            Power::PurchasableProducer(ProducedResources::Single(resource)) => format!("{}", resource),
-            Power::PurchasableProducer(ProducedResources::Choice(resources)) => format!("{}", resources.iter().format(" or ")),
-            Power::Producer(ProducedResources::Single(resource)) => format!("{}", resource),
-            Power::Producer(ProducedResources::Choice(resources)) => format!("{}", resources.iter().format(" or ")),
-            Power::VictoryPoints(points) => plural(*points, "VP"),
-            Power::Coins(coins) => plural(*coins, "coin"),
+            Power::PurchasableProducer(resources) => format!("{}", resources.iter().format(" or ")),
+            Power::Producer(resources) => format!("{}", resources.iter().format(" or ")),
+            Power::VictoryPoints(points) => plural(*points as i32, "VP"),
+            Power::Coins(coins) => plural(*coins as i32, "coin"),
             Power::BuyBrownAntiClockwise => "Buy brown cards for 1 coin anti-clockwise".to_string(),
             Power::BuyBrownClockwise => "Buy brown cards for 1 coin clockwise".to_string(),
             Power::BuyGrey => "Buy grey cards for 1 coin".to_string(),
             Power::Science(symbol) => format!("{}", symbol.iter().map(|symbol| format!("{} symbol", symbol)).format(" or ")),
-            Power::Shields(shields) => plural(*shields, "shield"),
+            Power::Shields(shields) => plural(*shields as i32, "shield"),
             Power::PerGameItemRewards(_) => "Per game item thing (TODO)".to_string()  // TODO
         })
     }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,6 +1,7 @@
-use std::fmt::{Display, Formatter};
+use std::cmp::max;
 use std::fmt;
-use std::ops::AddAssign;
+use std::fmt::{Display, Formatter};
+use std::ops::{AddAssign, SubAssign};
 
 use crate::utils::plural;
 
@@ -8,16 +9,16 @@ use crate::utils::plural;
 #[derive(Debug)]
 #[derive(Clone)]
 pub struct Resources {
-    pub coins: u32,
+    pub coins: i32,
 
-    pub wood: u32,
-    pub stone: u32,
-    pub ore: u32,
-    pub clay: u32,
+    pub wood: i32,
+    pub stone: i32,
+    pub ore: i32,
+    pub clay: i32,
 
-    pub glass: u32,
-    pub loom: u32,
-    pub papyrus: u32,
+    pub glass: i32,
+    pub loom: i32,
+    pub papyrus: i32,
 }
 
 impl Resources {
@@ -25,52 +26,101 @@ impl Resources {
         Resources { ..Default::default() }
     }
 
-    pub fn coins(num: u32) -> Resources {
+    pub fn coins(num: i32) -> Resources {
         Resources { coins: num, ..Default::default() }
     }
 
-    pub fn wood(num: u32) -> Resources {
+    pub fn wood(num: i32) -> Resources {
         Resources { wood: num, ..Default::default() }
     }
 
-    pub fn stone(num: u32) -> Resources {
+    pub fn stone(num: i32) -> Resources {
         Resources { stone: num, ..Default::default() }
     }
 
-    pub fn ore(num: u32) -> Resources {
+    pub fn ore(num: i32) -> Resources {
         Resources { ore: num, ..Default::default() }
     }
 
-    pub fn clay(num: u32) -> Resources {
+    pub fn clay(num: i32) -> Resources {
         Resources { clay: num, ..Default::default() }
     }
 
-    pub fn glass(num: u32) -> Resources {
+    pub fn glass(num: i32) -> Resources {
         Resources { glass: num, ..Default::default() }
     }
 
-    pub fn loom(num: u32) -> Resources {
+    pub fn loom(num: i32) -> Resources {
         Resources { loom: num, ..Default::default() }
     }
 
-    pub fn papyrus(num: u32) -> Resources {
+    pub fn papyrus(num: i32) -> Resources {
         Resources { papyrus: num, ..Default::default() }
     }
 
-    /// If this Resources object represents the resources at a user's disposal, then returns `true`
-    /// if the user can afford a card whose cost is represented by the given Resources object.
-    ///
-    /// More formally, returns `true` if and only if, for each resource type, this Resources object
-    /// has at least as much of the resource type as the given Resources object.
-    pub fn can_afford(&self, other: &Self) -> bool {
-        self.coins >= other.coins &&
-            self.wood >= other.wood &&
-            self.stone >= other.stone &&
-            self.ore >= other.ore &&
-            self.clay >= other.clay &&
-            self.glass >= other.glass &&
-            self.loom >= other.loom &&
-            self.papyrus >= other.papyrus
+    // TODO: the below methods (satisfied, has, not_needed, max, split) are pretty weird and hacky. I think maybe we
+    //  need to separate the concept of an overall Resources object as we have today, representing something like the
+    //  cost of building a card (eg. the Town Hall: 1 glass, 1 ore, 2 stone); and the concept of a resource as provided
+    //  by a built brown, grey, or yellow card, which is always (possibly a choice of) a single resource type. They work
+    //  slightly differently, are needed for different things, but occasionally interact when we need to add up
+    //  instances of the latter to see if we can get to the former.
+
+    /// Returns true if and only if all individual resource counts are at zero or below. If a cost is initialised as a
+    /// Resources object and then available resources are subtracted from it, then this returns true if there were
+    /// enough resources to afford the cost.
+    pub fn satisfied(&self) -> bool {
+        self.coins <= 0 &&
+            self.wood <= 0 &&
+            self.stone <= 0 &&
+            self.ore <= 0 &&
+            self.clay <= 0 &&
+            self.glass <= 0 &&
+            self.loom <= 0 &&
+            self.papyrus <= 0
+    }
+
+    /// Returns true if and only if this resource has at least one of each individual resource the given Resources
+    /// object has.
+    pub fn has(&self, required: &Resources) -> bool {
+        required.coins > 0 && self.coins > 0 ||
+        required.wood > 0 && self.wood > 0 ||
+        required.stone > 0 && self.stone > 0 ||
+        required.ore > 0 && self.ore > 0 ||
+        required.clay > 0 && self.clay > 0 ||
+        required.glass > 0 && self.glass > 0 ||
+        required.loom > 0 && self.loom > 0 ||
+        required.papyrus > 0 && self.papyrus > 0
+    }
+
+    /// Returns true if and only if, for some individual resource, the given Resources object has that resource and this
+    /// one does not.
+    pub fn not_needed(&self, r: &Resources) -> bool {
+        (r.wood > 0 && self.wood <= 0) ||
+        (r.stone > 0 && self.stone <= 0)||
+        (r.ore > 0 && self.ore <= 0) ||
+        (r.clay > 0 && self.clay <= 0) ||
+        (r.glass > 0 && self.glass <= 0) ||
+        (r.loom > 0 && self.loom <= 0) ||
+        (r.papyrus > 0 && self.papyrus <= 0)
+    }
+
+    /// Returns the maximum number of items of any given single resource.
+    pub fn max(&self) -> i32 {
+        max(self.wood, max(self.stone, max(self.ore, max(self.clay, max(self.glass, max(self.loom, self.papyrus))))))
+    }
+
+    /// Returns a new Resources object with each individual resource quantity halved.
+    pub fn split(&self) -> Resources {
+        Resources {
+            coins: self.coins,
+            wood: self.wood / 2,
+            stone: self.stone / 2,
+            ore: self.ore / 2,
+            clay: self.clay / 2,
+            glass: self.glass / 2,
+            loom: self.loom / 2,
+            papyrus: self.papyrus / 2,
+        }
     }
 }
 
@@ -89,10 +139,25 @@ impl AddAssign<&Resources> for Resources {
     }
 }
 
+impl SubAssign<&Resources> for Resources {
+    fn sub_assign(&mut self, other: &Self) {
+        *self = Self {
+            coins: self.coins - other.coins,
+            wood: self.wood - other.wood,
+            stone: self.stone - other.stone,
+            ore: self.ore - other.ore,
+            clay: self.clay - other.clay,
+            glass: self.glass - other.glass,
+            loom: self.loom - other.loom,
+            papyrus: self.papyrus - other.papyrus
+        }
+    }
+}
+
 /// Example formatting: `2 wood, 1 glass, 1 papyrus`
 impl Display for Resources {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fn add_if_non_zero(count: u32, resource: &str, resources: &mut Vec<String>) {
+        fn add_if_non_zero(count: i32, resource: &str, resources: &mut Vec<String>) {
             if count > 0 {
                 resources.push(format!("{} {}", count, resource));
             }
@@ -116,10 +181,4 @@ impl Display for Resources {
             write!(f, "{}", resources.join(", "))
         }
     }
-}
-
-pub enum ProducedResources {
-    // TODO: do we need this distinction or can things just use a vector of 1 to represent Single?
-    Single(Resources),
-    Choice(Vec<Resources>),
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@
 /// assert_eq!(plural(1, "coin"), "1 coin");
 /// assert_eq!(plural(2, "coin"), "2 coins");
 /// ```
-pub fn plural(count: u32, word: &str) -> String {
+pub fn plural(count: i32, word: &str) -> String {
     if count == 1 {
         format!("{} {}", count, word)
     } else {


### PR DESCRIPTION
The Random PlayingAlgorithm now chooses randomly from cards that require
borrowing (as well as those that don't). The Human algorithm doesn't
yet allow borrowing. Borrowing always costs two coins for now.

This change also gets rid of the distinction between Single and Choice
ProducedResources. Instead we just directly include a Vec inside a
Producer or PurchasableProducer, where a singleton Vec means a single
choice and multiple elements represents a choice. I don't think the
distinction was actually useful.

This also changes various u32 values to i32 instead (eg. inside
Resources). Although these should in theory always be positive, it's
very annoying when subtracting and then checking whether something goes
below zero or not.