### PR TITLE
Allow the human algorithm to borrow resources from neighbours

### DIFF
--- a/src/algorithms/human.rs
+++ b/src/algorithms/human.rs
@@ -7,7 +7,8 @@ use crate::algorithms::PlayingAlgorithm;
 use crate::game::VisibleGame;
 use crate::player::Player;
 use crate::table::Table;
-use crate::action::{Action, Borrowing};
+use crate::action::{Action, Borrowing, ActionOptions};
+use itertools::Itertools;
 
 #[derive(Debug)]
 pub struct Human;
@@ -68,25 +69,35 @@ impl Human {
         let action = loop {
             println!();
             print!("Please enter the id of the card to play: ");
-
-            let card = loop {
-                io::stdout().flush().unwrap();  // Needed so that print! (with no carriage return) flushes to the terminal.
-                let mut id = String::new();
-                io::stdin().read_line(&mut id).unwrap();
-                let id = id.trim().parse().unwrap_or(0);
-                if id > 0 && id <= hand.len() {
-                    break hand[id - 1];
-                }
-                print!("Please enter a number between 1 and {} inclusive: ", hand.len());
-            };
+            let card = *Self::choose_from_slice(&hand);
 
             print!("And now choose (b) to build or (d) to discard: ");
-            let action = loop {
+            let action = 'outer: loop {
                 io::stdout().flush().unwrap();
                 let mut choice = String::new();
                 io::stdin().read_line(&mut choice).unwrap();
                 match choice.trim().to_lowercase().as_str() {
-                    "b" => break Action::Build(card, Borrowing::no_borrowing()),
+                    "b" => {
+                        let options = player.options_for_card(&card, visible_game);
+                        if options.own_cards_only() || !options.possible() {
+                            // Use own cards, or action not possible (which is caught later).
+                            break Action::Build(card, Borrowing::no_borrowing())
+                        } else if options.actions.len() == 1 {
+                            // Borrowing, but only one option, so just do it.
+                            break options.actions[0].clone();
+                        } else {
+                            // Have user select which borrowing option to go with.
+                            println!();
+                            println!("Options for borrowing required resources:");
+                            Self::print_borrowing_options(
+                                &options,
+                                visible_game.left_neighbour_index(),
+                                visible_game.right_neighbour_index(),
+                                &mut io::stdout());
+                            print!("Please enter the id of the borrow you want to make: ");
+                            break 'outer Self::choose_from_slice(&options.actions).clone();
+                        }
+                    },
                     "d" => break Action::Discard(card),
                     _ => {},
                 };
@@ -100,14 +111,97 @@ impl Human {
             }
         };
 
-        println!("Selected action: {}", action.to_string());
-
+        println!();
         action
+    }
+
+    /// Asks the user to choose one of the items in the given slice.
+    fn choose_from_slice<T>(slice: &[T]) -> &T {
+        loop {
+            io::stdout().flush().unwrap();  // Needed so that print! (with no carriage return) flushes to the terminal.
+            let mut id = String::new();
+            io::stdin().read_line(&mut id).unwrap();
+            let id: usize = id.trim().parse().unwrap_or(0);
+            if id > 0 && id <= slice.len() {
+                return &slice[id - 1];
+            }
+            print!("Please enter a number between 1 and {} inclusive: ", slice.len());
+        }
+    }
+
+    /// Prints the borrowing options the user has available to them.
+    fn print_borrowing_options<W: Write>(
+            options: &ActionOptions,
+            left_neighbour_index: usize,
+            right_neighbour_index: usize,
+            out: &mut W) {
+        for (index, option) in options.actions.iter().enumerate() {
+            if let Action::Build(_, borrowing) = option {
+                let mut borrows = vec![];
+                if !borrowing.left.is_empty() {
+                    borrows.push(format!("{} from player {}", borrowing.left.iter()
+                        .map(|borrow| borrow.card)
+                        .format(", "), left_neighbour_index + 1));
+                }
+                if !borrowing.right.is_empty() {
+                    borrows.push(format!("{} from player {}", borrowing.right.iter()
+                        .map(|borrow| borrow.card)
+                        .format(", "), right_neighbour_index + 1));
+                }
+                writeln!(out, "   {}) Borrow {}", index + 1, borrows.iter().format(" and ")).unwrap();
+            }
+        }
     }
 }
 
 impl PlayingAlgorithm for Human {
     fn get_next_action(&self, player: &Player, visible_game: &VisibleGame) -> Action {
         Self::ask_for_action(player, visible_game)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::card::Card;
+    use crate::action::Borrow;
+
+    #[test]
+    fn print_borrowing_options_with_single_borrow() {
+        let mut out: Vec<u8> = Vec::new();
+        let actions = vec![Action::Build(Card::Baths, Borrowing::new(vec![Borrow::new(Card::StonePit, 0)], vec![]))];
+        Human::print_borrowing_options(&ActionOptions { actions }, 2, 0, &mut out);
+        assert_eq!(String::from_utf8(out).unwrap(), "   1) Borrow Stone Pit from player 3\n");
+    }
+
+    #[test]
+    fn print_borrowing_options_with_two_borrows_from_same_neighbour() {
+        let mut out: Vec<u8> = Vec::new();
+        let actions = vec![Action::Build(Card::Temple, Borrowing::new(
+            vec![], vec![Borrow::new(Card::LumberYard, 0), Borrow::new(Card::ClayPool, 0)]
+        ))];
+        Human::print_borrowing_options(&ActionOptions { actions }, 2, 0, &mut out);
+        assert_eq!(String::from_utf8(out).unwrap(), "   1) Borrow Lumber Yard, Clay Pool from player 1\n");
+    }
+
+    #[test]
+    fn print_borrowing_options_with_one_borrow_from_each_neighbour() {
+        let mut out: Vec<u8> = Vec::new();
+        let actions = vec![Action::Build(Card::Temple, Borrowing::new(
+            vec![Borrow::new(Card::LumberYard, 0)], vec![Borrow::new(Card::ClayPool, 0)]
+        ))];
+        Human::print_borrowing_options(&ActionOptions { actions }, 2, 0, &mut out);
+        assert_eq!(String::from_utf8(out).unwrap(), "   1) Borrow Lumber Yard from player 3 and Clay Pool from player 1\n");
+    }
+
+    #[test]
+    fn print_borrowing_options_with_two_options() {
+        let mut out: Vec<u8> = Vec::new();
+        let actions = vec![
+            Action::Build(Card::Baths, Borrowing::new(vec![Borrow::new(Card::StonePit, 0)], vec![])),
+            Action::Build(Card::Baths, Borrowing::new(vec![Borrow::new(Card::Excavation, 0)], vec![])),
+        ];
+        Human::print_borrowing_options(&ActionOptions { actions }, 2, 0, &mut out);
+        assert_eq!(String::from_utf8(out).unwrap(), "   1) Borrow Stone Pit from player 3\n   2) Borrow Excavation from player 3\n");
     }
 }

--- a/src/algorithms/random.rs
+++ b/src/algorithms/random.rs
@@ -15,8 +15,8 @@ impl PlayingAlgorithm for Random {
     fn get_next_action(&self, player: &Player, visible_game: &VisibleGame) -> Action {
         let action_to_take = player.hand().iter()
             .map(|card| player.options_for_card(card, visible_game))
-            .filter(|actions| !actions.is_empty())
-            .map(|mut actions| actions.swap_remove(thread_rng().gen_range(0, actions.len())))
+            .filter(|actions| actions.possible())
+            .map(|mut actions| actions.actions.swap_remove(thread_rng().gen_range(0, actions.actions.len())))
             .choose(&mut thread_rng());
 
         match action_to_take {

--- a/src/game.rs
+++ b/src/game.rs
@@ -150,14 +150,24 @@ pub struct VisibleGame<'a> {
 }
 
 impl<'a> VisibleGame<'a> {
-    // Returns the [`PublicPlayer`] on the current player's left, ie. clockwise.
+    /// Returns the [`PublicPlayer`] on the current player's left, ie. clockwise.
     pub fn left_neighbour(&self) -> &PublicPlayer {
-        &self.players[(self.player_index + 1) % self.players.len()]
+        &self.players[self.left_neighbour_index()]
     }
 
-    // Returns the [`PublicPlayer`] on the current player's right, ie. anti-clockwise.
+    /// Returns the [`PublicPlayer`] on the current player's right, ie. anti-clockwise.
     pub fn right_neighbour(&self) -> &PublicPlayer {
-        &self.players[(self.player_index + self.players.len() - 1) % self.players.len()]
+        &self.players[self.right_neighbour_index()]
+    }
+
+    /// Returns the 0-based index of the left neighbour.
+    pub fn left_neighbour_index(&self) -> usize {
+        (self.player_index + 1) % self.players.len()
+    }
+
+    /// Returns the 0-based index of the right neighbour.
+    pub fn right_neighbour_index(&self) -> usize {
+        (self.player_index + self.players.len() - 1) % self.players.len()
     }
 }
 


### PR DESCRIPTION
If a single borrow option is available, use it. If several borrow
options are available, print them and allow the user to select which one
to use.