### PR TITLE
PlayingAlgorithm.get_next_action() needs to mutate self

### DIFF
--- a/src/algorithms/human.rs
+++ b/src/algorithms/human.rs
@@ -16,7 +16,7 @@ pub struct Human;
 impl Human {
     /// Prints out the current game state for the given user index.
     fn print_state_for_user(player: &Player, visible_game: &VisibleGame) {
-        let all_players = visible_game.players;
+        let all_players = visible_game.public_players;
         let player_index = visible_game.player_index;
 
         // Offset the players so the player we're controller ends up in the middle.
@@ -192,7 +192,7 @@ impl Human {
 }
 
 impl PlayingAlgorithm for Human {
-    fn get_next_action(&self, player: &Player, visible_game: &VisibleGame) -> Action {
+    fn get_next_action(&mut self, player: &Player, visible_game: &VisibleGame) -> Action {
         Self::ask_for_action(player, visible_game)
     }
 }

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -14,5 +14,5 @@ pub trait PlayingAlgorithm: Debug {
     /// Returns the action that should be performed by the given player.
     ///
     /// `visible_game` is a restricted view of the state of all players in the game.
-    fn get_next_action(&self, player: &Player, visible_game: &VisibleGame) -> Action;
+    fn get_next_action(&mut self, player: &Player, visible_game: &VisibleGame) -> Action;
 }

--- a/src/algorithms/random.rs
+++ b/src/algorithms/random.rs
@@ -12,7 +12,7 @@ use crate::player::Player;
 pub struct Random;
 
 impl PlayingAlgorithm for Random {
-    fn get_next_action(&self, player: &Player, visible_game: &VisibleGame) -> Action {
+    fn get_next_action(&mut self, player: &Player, visible_game: &VisibleGame) -> Action {
         let action_to_take = player
             .hand()
             .iter()

--- a/src/game.rs
+++ b/src/game.rs
@@ -17,7 +17,7 @@ pub struct Game {
     /// around the table of players. The player at the end of the vector also sits next to player at index 0, of course.
     /// For example, for a game of 5 players, the player at index 1 sits to the left (ie. clockwise) of the player at
     /// index 0, and the player at index 4 sits to the right (ie. anti-clockwise) of the player at index 0.
-    players: Vec<Player>,
+    sentient_players: Vec<SentientPlayer>,
 
     /// The game turn. Runs from 0 to 17 for 3 ages of 6 turns each.
     turn: u32,
@@ -44,14 +44,17 @@ impl Game {
         wonder_types.shuffle(&mut thread_rng());
 
         // For each player, pick a random wonder and deal seven random cards.
-        let players: Vec<Player> = algorithms
+        let sentient_players = algorithms
             .into_iter()
             .zip(wonder_types)
-            .map(|(algorithm, wonder_type)| Player::new(wonder_type, WonderSide::A, algorithm))
+            .map(|(algorithm, wonder_type)| SentientPlayer {
+                player: Player::new(wonder_type, WonderSide::A),
+                algorithm,
+            })
             .collect();
 
         Game {
-            players,
+            sentient_players,
             turn: 0,
             discard_pile: vec![],
         }
@@ -62,7 +65,10 @@ impl Game {
         for _ in 0..18 {
             self.do_turn();
         }
-        self.players.iter().map(|player| player.strength() as i32).collect()
+        self.sentient_players
+            .iter()
+            .map(|sentient_player| sentient_player.player.strength() as i32)
+            .collect()
     }
 
     /// Executes a turn of the game. Gets an [`Action`] from each [`Player`] and updates the game state accordingly.
@@ -70,8 +76,8 @@ impl Game {
         // At the start of each age, deal new cards and add any remaining cards to the discard pile.
         if self.turn % 6 == 0 {
             let mut deck = card::new_deck(self.age(), self.player_count());
-            for player in self.players.iter_mut() {
-                let old_hand = player.swap_hand(deck.drain(0..7).collect());
+            for sentient_player in self.sentient_players.iter_mut() {
+                let old_hand = sentient_player.player.swap_hand(deck.drain(0..7).collect());
                 for card in old_hand {
                     self.discard_pile.push(card);
                 }
@@ -80,26 +86,32 @@ impl Game {
 
         // Do actions. public_players is an immutable snapshot of the game state before players start moving, so
         // that each moves "simultaneously".
-        let public_players: Vec<PublicPlayer> = self.players.iter().map(|player| PublicPlayer::new(&player)).collect();
-        for index in 0..self.players.len() {
-            let (mut right_player, player, mut left_player) =
-                Self::get_mutable_player_and_neighbours(&mut self.players, index);
+        let public_players: Vec<PublicPlayer> = self
+            .sentient_players
+            .iter()
+            .map(|sentient_player| PublicPlayer::new(&sentient_player.player))
+            .collect();
+        for index in 0..self.sentient_players.len() {
+            let (right_player, sentient_player, left_player) =
+                Self::get_mutable_player_and_neighbours(&mut self.sentient_players, index);
             let visible_game = VisibleGame {
-                players: &public_players,
+                public_players: &public_players,
                 player_index: index,
             };
-            let action = player.algorithm().get_next_action(&player, &visible_game);
-            player.do_action(
+            let action = sentient_player
+                .algorithm
+                .get_next_action(&sentient_player.player, &visible_game);
+            sentient_player.player.do_action(
                 &action,
                 &visible_game,
-                &mut left_player,
-                &mut right_player,
+                &mut left_player.player,
+                &mut right_player.player,
                 &mut self.discard_pile,
             );
         }
 
         // Pass cards.
-        let num_players = self.players.len();
+        let num_players = self.sentient_players.len();
         let mut hand = vec![];
         for i in 0..num_players + 1 {
             let index = if self.age() == Age::Second {
@@ -109,14 +121,14 @@ impl Game {
                 // Otherwise, pass clockwise.
                 i
             } % num_players;
-            hand = self.players[index].swap_hand(hand);
+            hand = self.sentient_players[index].player.swap_hand(hand);
         }
 
         self.turn += 1;
     }
 
     pub fn player_count(&self) -> u32 {
-        self.players.len() as u32
+        self.sentient_players.len() as u32
     }
 
     /// Returns the current age being played.
@@ -132,9 +144,9 @@ impl Game {
     /// Given the index of a player, returns a mutable borrow of that player, as well as the left and right neighbours
     /// of the player. This is super-horrible in Rust as far as I can tell. Perhaps there's a better way...
     fn get_mutable_player_and_neighbours(
-        players: &mut Vec<Player>,
+        players: &mut Vec<SentientPlayer>,
         index: usize,
-    ) -> (&mut Player, &mut Player, &mut Player) {
+    ) -> (&mut SentientPlayer, &mut SentientPlayer, &mut SentientPlayer) {
         if index == 0 {
             // player=0, left=1, right=n
             let (player, after) = players.split_first_mut().unwrap();
@@ -156,11 +168,21 @@ impl Game {
     }
 }
 
+/// A [`Player`] and a [`PlayingAlgorithm`]. `PlayingAlgorithm` can't live inside `Player` because we need to allow
+/// algorithm implementations to maintain state and therefore be mutable when called. They also need access to the data
+/// and methods of `Player` in order to make decisions. Therefore, we'd have a mutable and immutable borrow at the same
+/// time.
+#[derive(Debug)]
+struct SentientPlayer {
+    player: Player,
+    algorithm: Box<dyn PlayingAlgorithm>,
+}
+
 /// The state of the game visible to all players (ie. excluding things like players' hands).
 #[derive(Debug)]
 pub struct VisibleGame<'a> {
     /// All players in the game.
-    pub players: &'a [PublicPlayer],
+    pub public_players: &'a [PublicPlayer],
     /// The index of the player this has been generated for.
     pub player_index: usize,
 }
@@ -168,22 +190,22 @@ pub struct VisibleGame<'a> {
 impl<'a> VisibleGame<'a> {
     /// Returns the [`PublicPlayer`] on the current player's left, ie. clockwise.
     pub fn left_neighbour(&self) -> &PublicPlayer {
-        &self.players[self.left_neighbour_index()]
+        &self.public_players[self.left_neighbour_index()]
     }
 
     /// Returns the [`PublicPlayer`] on the current player's right, ie. anti-clockwise.
     pub fn right_neighbour(&self) -> &PublicPlayer {
-        &self.players[self.right_neighbour_index()]
+        &self.public_players[self.right_neighbour_index()]
     }
 
     /// Returns the 0-based index of the left neighbour.
     pub fn left_neighbour_index(&self) -> usize {
-        (self.player_index + 1) % self.players.len()
+        (self.player_index + 1) % self.public_players.len()
     }
 
     /// Returns the 0-based index of the right neighbour.
     pub fn right_neighbour_index(&self) -> usize {
-        (self.player_index + self.players.len() - 1) % self.players.len()
+        (self.player_index + self.public_players.len() - 1) % self.public_players.len()
     }
 }
 
@@ -248,15 +270,15 @@ mod tests {
     fn do_turn_deals_new_cards_at_the_start_of_each_age() {
         let mut game = Game::new(vec![Box::new(Random {}), Box::new(Random {}), Box::new(Random {})]);
         game.do_turn();
-        assert_eq!(6, game.players[0].hand().len());
+        assert_eq!(6, game.sentient_players[0].player.hand().len());
         for _i in 0..6 {
             game.do_turn();
         }
-        assert_eq!(6, game.players[0].hand().len());
+        assert_eq!(6, game.sentient_players[0].player.hand().len());
         for _i in 0..6 {
             game.do_turn();
         }
-        assert_eq!(6, game.players[0].hand().len());
+        assert_eq!(6, game.sentient_players[0].player.hand().len());
     }
 
     #[test]
@@ -271,40 +293,52 @@ mod tests {
         // cards!
         game.do_turn();
 
-        let player0 = game.players[0].hand().clone();
-        let player1 = game.players[1].hand().clone();
-        let player2 = game.players[2].hand().clone();
+        let player0 = game.sentient_players[0].player.hand().clone();
+        let player1 = game.sentient_players[1].player.hand().clone();
+        let player2 = game.sentient_players[2].player.hand().clone();
 
         game.do_turn();
 
-        assert_eq!(game.players[1].hand()[..], player0[..player0.len() - 1]);
-        assert_eq!(game.players[2].hand()[..], player1[..player0.len() - 1]);
-        assert_eq!(game.players[0].hand()[..], player2[..player0.len() - 1]);
+        assert_eq!(game.sentient_players[1].player.hand()[..], player0[..player0.len() - 1]);
+        assert_eq!(game.sentient_players[2].player.hand()[..], player1[..player0.len() - 1]);
+        assert_eq!(game.sentient_players[0].player.hand()[..], player2[..player0.len() - 1]);
     }
 
     #[test]
     fn get_mutable_player_and_neighbours() {
         let mut players = vec![
-            Player::new(WonderType::ColossusOfRhodes, WonderSide::A, Box::new(Random {})),
-            Player::new(WonderType::LighthouseOfAlexandria, WonderSide::A, Box::new(Random {})),
-            Player::new(WonderType::TempleOfArtemis, WonderSide::A, Box::new(Random {})),
-            Player::new(WonderType::HangingGardensOfBabylon, WonderSide::A, Box::new(Random {})),
+            SentientPlayer {
+                player: Player::new(WonderType::ColossusOfRhodes, WonderSide::A),
+                algorithm: Box::new(Random {}),
+            },
+            SentientPlayer {
+                player: Player::new(WonderType::LighthouseOfAlexandria, WonderSide::A),
+                algorithm: Box::new(Random {}),
+            },
+            SentientPlayer {
+                player: Player::new(WonderType::TempleOfArtemis, WonderSide::A),
+                algorithm: Box::new(Random {}),
+            },
+            SentientPlayer {
+                player: Player::new(WonderType::HangingGardensOfBabylon, WonderSide::A),
+                algorithm: Box::new(Random {}),
+            },
         ];
 
         let (right, player, left) = Game::get_mutable_player_and_neighbours(&mut players, 0);
-        assert_eq!(WonderType::HangingGardensOfBabylon, right.wonder().wonder_type);
-        assert_eq!(WonderType::ColossusOfRhodes, player.wonder().wonder_type);
-        assert_eq!(WonderType::LighthouseOfAlexandria, left.wonder().wonder_type);
+        assert_eq!(WonderType::HangingGardensOfBabylon, right.player.wonder().wonder_type);
+        assert_eq!(WonderType::ColossusOfRhodes, player.player.wonder().wonder_type);
+        assert_eq!(WonderType::LighthouseOfAlexandria, left.player.wonder().wonder_type);
 
         let (right, player, left) = Game::get_mutable_player_and_neighbours(&mut players, 1);
-        assert_eq!(WonderType::ColossusOfRhodes, right.wonder().wonder_type);
-        assert_eq!(WonderType::LighthouseOfAlexandria, player.wonder().wonder_type);
-        assert_eq!(WonderType::TempleOfArtemis, left.wonder().wonder_type);
+        assert_eq!(WonderType::ColossusOfRhodes, right.player.wonder().wonder_type);
+        assert_eq!(WonderType::LighthouseOfAlexandria, player.player.wonder().wonder_type);
+        assert_eq!(WonderType::TempleOfArtemis, left.player.wonder().wonder_type);
 
         let (right, player, left) = Game::get_mutable_player_and_neighbours(&mut players, 3);
-        assert_eq!(WonderType::TempleOfArtemis, right.wonder().wonder_type);
-        assert_eq!(WonderType::HangingGardensOfBabylon, player.wonder().wonder_type);
-        assert_eq!(WonderType::ColossusOfRhodes, left.wonder().wonder_type);
+        assert_eq!(WonderType::TempleOfArtemis, right.player.wonder().wonder_type);
+        assert_eq!(WonderType::HangingGardensOfBabylon, player.player.wonder().wonder_type);
+        assert_eq!(WonderType::ColossusOfRhodes, left.player.wonder().wonder_type);
     }
 
     #[test]
@@ -321,7 +355,7 @@ mod tests {
     #[derive(Debug)]
     pub struct AlwaysDiscards;
     impl PlayingAlgorithm for AlwaysDiscards {
-        fn get_next_action(&self, player: &Player, _visible_game: &VisibleGame) -> Action {
+        fn get_next_action(&mut self, player: &Player, _visible_game: &VisibleGame) -> Action {
             // TODO: we always discard the last card so the order of the hand is not disrupted (because
             //  player::do_action uses Vec::swap_remove). Ideally don't rely on the implementation of do_action. But
             //  that involves sorting the hands in order to compare them, which is painful (at least with my current

--- a/src/player.rs
+++ b/src/player.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use std::mem;
 
 use crate::action::{Action, ActionOptions, Borrow, Borrowing};
-use crate::algorithms::PlayingAlgorithm;
 use crate::card::{Card, Colour};
 use crate::game::VisibleGame;
 use crate::power::Power;
@@ -13,7 +12,6 @@ use crate::wonder::{WonderBoard, WonderSide, WonderType};
 
 #[derive(Debug)]
 pub struct Player {
-    algorithm: Box<dyn PlayingAlgorithm>,
     wonder: WonderBoard,
     built_structures: Vec<Card>,
     built_wonder_stages: Vec<Option<Card>>, // TODO: how to represent this?
@@ -23,9 +21,8 @@ pub struct Player {
 
 #[allow(dead_code)]
 impl Player {
-    pub fn new(wonder_type: WonderType, wonder_side: WonderSide, algorithm: Box<dyn PlayingAlgorithm>) -> Player {
+    pub fn new(wonder_type: WonderType, wonder_side: WonderSide) -> Player {
         Player {
-            algorithm,
             wonder: WonderBoard {
                 wonder_type,
                 wonder_side,
@@ -35,10 +32,6 @@ impl Player {
             coins: 3,
             hand: vec![],
         }
-    }
-
-    pub fn algorithm(&self) -> &dyn PlayingAlgorithm {
-        &*self.algorithm
     }
 
     pub fn wonder(&self) -> &WonderBoard {
@@ -393,8 +386,6 @@ impl PublicPlayer {
 #[cfg(test)]
 mod tests {
     use Card::*;
-
-    use crate::algorithms::random::Random;
 
     use super::*;
 
@@ -838,14 +829,14 @@ mod tests {
     }
 
     fn new_player(hand: Vec<Card>) -> Player {
-        let mut player = Player::new(WonderType::ColossusOfRhodes, WonderSide::A, Box::new(Random {}));
+        let mut player = Player::new(WonderType::ColossusOfRhodes, WonderSide::A);
         player.swap_hand(hand);
         player
     }
 
-    fn visible_game(players: &[PublicPlayer]) -> VisibleGame {
+    fn visible_game(public_players: &[PublicPlayer]) -> VisibleGame {
         VisibleGame {
-            players,
+            public_players,
             player_index: 1,
         }
     }


### PR DESCRIPTION
When we start on slightly more sophisticated playing algorithms, they'll
need to maintain state and mutate it when calculating their next
action (eg. keeping track of which cards are probably where).

The algorithms still need access to Player so they can see the current
hand and call can_play(), options_for_card() etc. This is a problem
because we need to pass an immutable borrow of Player while calling
PlayingAlgorithm.get_next_action() with a mutable borrow of self. With
PlayingAlgorithm inside Player this leads to a mutable borrow at the
same time as an immutable borrow of Player. Therefore, we need to
separate the instance of PlayingAlgorithm from Player and store it
alongside instead (either that or clone all the player data each call,
which is expensive).