### PR TITLE
The Random algorithm just needs one random borrow option

### DIFF
--- a/src/algorithms/human.rs
+++ b/src/algorithms/human.rs
@@ -61,7 +61,7 @@ impl Human {
             .iter()
             .enumerate()
             .map(|(i, card)| {
-                let options = player.options_for_card(card, visible_game);
+                let options = player.options_for_card(card, visible_game, false);
                 let playability = if !options.possible() {
                     "  "
                 } else if options.own_cards_only() {
@@ -108,7 +108,7 @@ impl Human {
                 io::stdin().read_line(&mut choice).unwrap();
                 match choice.trim().to_lowercase().as_str() {
                     "b" => {
-                        let options = player.options_for_card(&card, visible_game);
+                        let options = player.options_for_card(&card, visible_game, false);
                         if options.own_cards_only() || !options.possible() {
                             // Use own cards, or action not possible (which is caught later).
                             break Action::Build(card, Borrowing::no_borrowing());

--- a/src/algorithms/monte_carlo.rs
+++ b/src/algorithms/monte_carlo.rs
@@ -21,7 +21,7 @@ impl PlayingAlgorithm for MonteCarlo {
         // Build a vector of possible actions. We'll evaluate the strength of each and pick the best.
         let mut action_options = Vec::new();
         for card in player.hand() {
-            let mut options = player.options_for_card(card, visible_game);
+            let mut options = player.options_for_card(card, visible_game, false);
             if options.possible() {
                 // TODO: for now, just take one option. This will be the only option if the card can be played without
                 //  borrowing; otherwise in many cases it will be the one-and-only borrow option. Sometimes, though,

--- a/src/algorithms/random.rs
+++ b/src/algorithms/random.rs
@@ -21,13 +21,9 @@ pub fn get_next_action(player: &Player, visible_game: &VisibleGame) -> Action {
     let action_to_take = player
         .hand()
         .iter()
-        .map(|card| player.options_for_card(card, visible_game))
+        .map(|card| player.options_for_card(card, visible_game, true))
         .filter(|actions| actions.possible())
-        .map(|mut actions| {
-            actions
-                .actions
-                .swap_remove(thread_rng().gen_range(0, actions.actions.len()))
-        })
+        .map(|mut actions| actions.actions.swap_remove(0))
         .choose(&mut thread_rng());
 
     match action_to_take {


### PR DESCRIPTION
We were finding all possible ways of borrowing resources in order to
build a card, and then picking one of those randomly. Instead, find just
one valid borrow option, but make sure we find it in a way that allows
each possible option equal chance of being selected.

This allows us to bail out earlier in many cases. It reduces the time to
run MonteCarlo::get_next_action by 20%.